### PR TITLE
refactor: :necktie: ReprocessPendingAuthorization usecase

### DIFF
--- a/core/usecase/reprocessPendingAuthorization.go
+++ b/core/usecase/reprocessPendingAuthorization.go
@@ -27,12 +27,6 @@ func (a *AuthorizationUsecase) ReprocessPendingAuthorization(auth *dto.Authoriza
 		return response, err
 	}
 
-	// if auth.AuthorizationID != authorization.GetID() {
-	// 	err = errors.New("authorization cannot be reprocessed, authorization id of the request does not match with existing")
-	// 	response.ErrorMessage = err.Error()
-	// 	return response, err
-	// }
-
 	if auth.ClientID != authorization.GetClientID() {
 		err = errors.New("authorization cannot be reprocessed, client id of the request does not match with existing")
 		response.ErrorMessage = err.Error()
@@ -52,6 +46,7 @@ func (a *AuthorizationUsecase) ReprocessPendingAuthorization(auth *dto.Authoriza
 		return response, err
 	}
 
+	response.AuthorizationID = authorization.GetID()
 	response.Status = newStatus
 	response.DeniedAt = dateTime.FormatDateToNull(authorization.DeniedAt())
 	response.ApprovedAt = dateTime.FormatDateToNull(authorization.ApprovedAt())


### PR DESCRIPTION
refactoring the business rule that allows/denies reprocessing and fixing the fill of the gRPC response with the authorization_id, which was missing